### PR TITLE
Fix build issue that would prevent build on modern ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INCS=-I/usr/local/include
-LIBS=-L/usr/local/lib -lgd
+LIBS=-L/usr/local/lib -lgd -lm
 CFLAGS=-g -Wall ${INCS}
 LDFLAGS=-g
 OBJS=\


### PR DESCRIPTION
I was getting this rather odd linking error:

```
ben@eshwil:/tmp/ipv4-heatmap$ make
cc -g -o ipv4-heatmap ipv4-heatmap.o xy_from_ip.o hilbert.o morton.o annotate.o shade.o legend.o bbox.o text.o cidr.o -L/usr/local/lib -lgd
/usr/bin/ld: legend.o: undefined reference to symbol 'exp@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:20: recipe for target 'ipv4-heatmap' failed
make: *** [ipv4-heatmap] Error 1
```

I fixed this by adding -lm to the libs, assuggested
by many on google.